### PR TITLE
Added volumes in mysql section.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
         restart: always
         networks:
             - main
+        volumes:
+            - ./db:/var/lib/mysql
     phpmyadmin:
         image: phpmyadmin/phpmyadmin
         container_name: phpmyadmin


### PR DESCRIPTION
Because we all want MySQL to have persistent storage (All DBs and their data should not delete after container restart)
 So in our _docker-compose.yml_  ,added this under mysql section:
    volumes:
            - ./db:/var/lib/mysql
Here db is the directory on host machine where we want the database to reside persistently.